### PR TITLE
Using <SparklinesCurve> in the chart for smoother curve

### DIFF
--- a/src/components/chart.js
+++ b/src/components/chart.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import React from 'react';
-import { Sparklines, SparklinesLine, SparklinesReferenceLine } from 'react-sparklines';
+import { Sparklines, SparklinesLine, SparklinesReferenceLine, SparklinesCurve } from 'react-sparklines';
 
 function average(data) {
   return _.round(_.sum(data) / data.length);
@@ -20,7 +20,7 @@ export default ({
         height={height}
         width={width}
         data={data}>
-        <SparklinesLine color={color} />
+        <SparklinesCurve color={color} divisor="0.33" />
         <SparklinesReferenceLine type={type} />
       </Sparklines>
       <div>{average(data)} {units}</div>


### PR DESCRIPTION
- for issue #1 
- to make curve in the chart smoother by setting divisor to 0.33 of `<SparklinesCurve>`

![compare-divosor-0 3](https://cloud.githubusercontent.com/assets/4994705/26428910/a9e29692-4116-11e7-87de-4e868bdd6006.png)
